### PR TITLE
patch: Exit 1 if docusaurus build fails

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,8 +37,8 @@ const config = {
   baseUrl: '/',
 
   // Optional 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
+  onBrokenLinks: 'warn',
+  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico', // use default, but overide if available
 
   // Even if you don't use internalization, you can use this field to set useful

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,9 @@ else
     . /app/docusaurusify.sh $1 $2 $3 $4
     cd /app
     npx docusaurus build
+    if [ $? -ne 0 ]; then
+        echo "An error during docusaurus build. Exiting with status code 1."
+        exit 1
+    fi
     cp -rf /app/build /github/workspace
 fi


### PR DESCRIPTION
This should fail the workflow when docusaurus fails to build. Atm, the master branch is broken and #94 will fix it. 

This PR is created to make sure Flowzone fails and that's what happened on the previous run which validates the functionality of this PR: https://github.com/product-os/docusaurus-builder/actions/runs/10389536198/job/28767954123

```
at Z (server.bundle.js:14787:89)
              at Yc (server.bundle.js:14790:98)
        },
        Error: Can't render static file for pathname "/"
            at generateStaticFile (/app/node_modules/@docusaurus/core/lib/ssg.js:119:15)
            at async /app/node_modules/p-map/index.js:57:22 {
          [cause]: TypeError: (0 , lib_namespaceObject.useContextualSearchFilters) is not a function
              at SearchBar (server.bundle.js:8676:833)
              at Uc (server.bundle.js:14779:44)
              at Xc (server.bundle.js:147[81](https://github.com/product-os/docusaurus-builder/actions/runs/10389536198/job/28767954123#step:7:82):253)
              at Z (server.bundle.js:14787:89)
              at Yc (server.bundle.js:14790:98)
              at Xc (server.bundle.js:147[82](https://github.com/product-os/docusaurus-builder/actions/runs/10389536198/job/28767954123#step:7:83):145)
              at Z (server.bundle.js:14787:89)
              at Xc (server.bundle.js:14781:481)
              at Z (server.bundle.js:14787:89)
              at Yc (server.bundle.js:14790:98)
        }
      ]
    }
  }
}
[INFO] Docusaurus version: 3.5.1
Node version: v18.20.3
An error occurred. Exiting with status code 1.
```

Also, removing the `throw` errors for broken links and markdown files to not break build pipelines since this PR will fail anything with an error.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
