### PR TITLE
patch: Configure rennovate to exclude cheerio package

### DIFF
--- a/.github/workflows/rennovate.json
+++ b/.github/workflows/rennovate.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["github>balena-io/renovate-config"],
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["cheerio"],
+      "enabled": false
+    }
+  ] 
+}


### PR DESCRIPTION
Docusaurus uses a local search plugin which requires overrides to be in place for it to function correctly. 
Without it the build will continue to break as rennovate would keep updating the override section dependencies that I am setting. 

Example: Made #96, renovate made #97 to revert my change, and now I am making #99 to revert rennovate's change after this gets merged.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
