### PR TITLE
patch: Update regex to match both HTML & Markdown docs paths

### DIFF
--- a/docusaurusify.sh
+++ b/docusaurusify.sh
@@ -29,7 +29,7 @@ if [ ! -e "/app/docs/README.md" ]; then
 fi
 
 # Replace all links that have .docs/ in top level README as we flatten the dir structure
-sed -i -r 's|\((\./)?docs/|\(\./|g' /app/docs/README.md
+sed -i -r 's|\(\./\)\?docs/|\./|g' /app/docs/README.md
 
 # Replace logo file if it exits
 LOGO_PATH=$GITHUB_WORKSPACE/logo.png


### PR DESCRIPTION
Initially the regex only targets markdown links. This was done to prevent targetting every `./docs` link in the README file but rethinking on it. If there is a path in the README that targets a file in the docs folder then that file will be published to docusarus as well which means it needs to be relative to the docs folder so that docusaurus can use it correctly

![Screenshot 2024-10-30 at 5 46 14 PM](https://github.com/user-attachments/assets/1f97e522-b758-43a0-b255-e4dcfe440799)
