### PR TITLE
Revert "patch: Update regex to match both HTML & Markdown docs paths"

### DIFF
--- a/docusaurusify.sh
+++ b/docusaurusify.sh
@@ -29,7 +29,7 @@ if [ ! -e "/app/docs/README.md" ]; then
 fi
 
 # Replace all links that have .docs/ in top level README as we flatten the dir structure
-sed -i -r 's|\(\./\)\?docs/|\./|g' /app/docs/README.md
+sed -i -r 's|\((\./)?docs/|\(\./|g' /app/docs/README.md
 
 # Replace logo file if it exits
 LOGO_PATH=$GITHUB_WORKSPACE/logo.png


### PR DESCRIPTION
Reverts product-os/docusaurus-builder#120

Reverting. Doesn't work for Flowzone readme. For example, this regex change replaces the path to create `././images/logo.png` --> `docs/docs/images/logo.png` which wasn't apparent in the testing since we are using relative links.

The actual error:
`Cause: Image docs/docs/images/logo.png used in docs/README.md not found.`

To unblock further updates of the docusaurus builder into Flowzone. I am reverting this change. 