### PR TITLE
Revert flowzone pinning to master

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   flowzone:
     name: Flowzone
-    uses: product-os/flowzone/.github/workflows/flowzone.yml@3eb3c97430ced517b32b40740187bf754857ba19 # master
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit
     with:
       cloudflare_website: docusaurus-builder


### PR DESCRIPTION
Revert flowzone workflow reference from SHA digest pin back to master branch.

The renovate-config repo now has package rules to prevent v43 from
re-pinning non-semver GitHub Actions refs to digests.

See: https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/198